### PR TITLE
worker/tee: split setup/restore and return io::Result

### DIFF
--- a/worker/src/tee.rs
+++ b/worker/src/tee.rs
@@ -1,81 +1,215 @@
-use nix::unistd::{close, dup, dup2};
+use nix::unistd::{dup, dup2};
 use std::fs::File;
 use std::io::{self, Write};
 use std::os::fd::{BorrowedFd, FromRawFd, OwnedFd};
-use std::os::unix::io::{AsRawFd, RawFd};
 use std::process::{Command, Stdio};
 
+/// Safe wrapper for capturing stdout/stderr to a file
+///
+/// This struct redirects stdout and stderr to either a file directly
+/// or through the `tee` command for simultaneous console and file output.
+/// File descriptors are properly managed to prevent leaks.
+#[derive(Debug)]
 pub struct CopyOutput {
-    old_stdout: OwnedFd,
-    old_stderr: OwnedFd,
+    old_stdout: Option<OwnedFd>,
+    old_stderr: Option<OwnedFd>,
     tee: bool,
     process: Option<std::process::Child>,
     newfd: Option<File>,
 }
 
 impl CopyOutput {
+    /// Create a new CopyOutput that redirects stdout/stderr to the specified file
+    ///
+    /// # Arguments
+    /// * `output_log` - Path to the output log file
+    /// * `tee` - If true, use `tee` command to show output on console and write to file
+    ///
+    /// # Safety
+    /// This function manipulates file descriptors. If the process panics or exits
+    /// unexpectedly, the original stdout/stderr may not be restored.
     pub fn new(output_log: &std::path::Path, tee: bool) -> io::Result<Self> {
-        let old_stdout = dup(unsafe { BorrowedFd::borrow_raw(nix::libc::STDOUT_FILENO) })
-            .expect("Failed to duplicate stdout");
-        let old_stderr = dup(unsafe { BorrowedFd::borrow_raw(nix::libc::STDERR_FILENO) })
-            .expect("Failed to duplicate stderr");
-
-        let mut process = None;
-        let newfd: Option<File>;
-
-        if tee {
-            let p = Command::new("tee")
-                .arg(output_log)
-                .stdin(Stdio::piped())
-                .spawn()?;
-            let mut stdout_fd = unsafe { OwnedFd::from_raw_fd(nix::libc::STDOUT_FILENO) };
-            let mut stderr_fd = unsafe { OwnedFd::from_raw_fd(nix::libc::STDERR_FILENO) };
-            dup2(p.stdin.as_ref().unwrap(), &mut stdout_fd)
-                .expect("Failed to redirect stdout to tee");
-            dup2(p.stdin.as_ref().unwrap(), &mut stderr_fd)
-                .expect("Failed to redirect stderr to tee");
-            std::mem::forget(stdout_fd);
-            std::mem::forget(stderr_fd);
-            process = Some(p);
-            newfd = None;
-        } else {
-            let file = File::create(output_log)?;
-            let mut stdout_fd = unsafe { OwnedFd::from_raw_fd(nix::libc::STDOUT_FILENO) };
-            let mut stderr_fd = unsafe { OwnedFd::from_raw_fd(nix::libc::STDERR_FILENO) };
-            dup2(&file, &mut stdout_fd).expect("Failed to redirect stdout to file");
-            dup2(&file, &mut stderr_fd).expect("Failed to redirect stderr to file");
-            std::mem::forget(stdout_fd);
-            std::mem::forget(stderr_fd);
-            newfd = Some(file);
+        // Validate the output path
+        if let Some(parent) = output_log.parent() {
+            if !parent.exists() {
+                return Err(io::Error::new(
+                    io::ErrorKind::NotFound,
+                    format!("Parent directory does not exist: {}", parent.display()),
+                ));
+            }
         }
 
-        Ok(Self {
-            old_stdout,
-            old_stderr,
+        // Safely duplicate file descriptors
+        let old_stdout =
+            dup(unsafe { BorrowedFd::borrow_raw(nix::libc::STDOUT_FILENO) }).map_err(|e| {
+                io::Error::new(
+                    io::ErrorKind::Other,
+                    format!("Failed to duplicate stdout: {}", e),
+                )
+            })?;
+
+        let old_stderr =
+            dup(unsafe { BorrowedFd::borrow_raw(nix::libc::STDERR_FILENO) }).map_err(|e| {
+                io::Error::new(
+                    io::ErrorKind::Other,
+                    format!("Failed to duplicate stderr: {}", e),
+                )
+            })?;
+
+        let mut copy_output = Self {
+            old_stdout: Some(old_stdout),
+            old_stderr: Some(old_stderr),
             tee,
-            process,
-            newfd,
-        })
+            process: None,
+            newfd: None,
+        };
+
+        // Set up redirection
+        if tee {
+            copy_output.setup_tee_redirection(output_log)?;
+        } else {
+            copy_output.setup_file_redirection(output_log)?;
+        }
+
+        Ok(copy_output)
+    }
+
+    /// Set up redirection through the `tee` command
+    fn setup_tee_redirection(&mut self, output_log: &std::path::Path) -> io::Result<()> {
+        let process = Command::new("tee")
+            .arg(output_log)
+            .stdin(Stdio::piped())
+            .spawn()
+            .map_err(|e| {
+                io::Error::new(
+                    io::ErrorKind::Other,
+                    format!("Failed to spawn tee process: {}", e),
+                )
+            })?;
+
+        let stdin_ref = process
+            .stdin
+            .as_ref()
+            .ok_or_else(|| io::Error::new(io::ErrorKind::Other, "Tee process has no stdin"))?;
+
+        // Redirect stdout and stderr to tee's stdin
+        let mut stdout_fd = unsafe { OwnedFd::from_raw_fd(nix::libc::STDOUT_FILENO) };
+        let mut stderr_fd = unsafe { OwnedFd::from_raw_fd(nix::libc::STDERR_FILENO) };
+        dup2(stdin_ref, &mut stdout_fd).map_err(|e| {
+            io::Error::new(
+                io::ErrorKind::Other,
+                format!("Failed to redirect stdout to tee: {}", e),
+            )
+        })?;
+        dup2(stdin_ref, &mut stderr_fd).map_err(|e| {
+            io::Error::new(
+                io::ErrorKind::Other,
+                format!("Failed to redirect stderr to tee: {}", e),
+            )
+        })?;
+        std::mem::forget(stdout_fd);
+        std::mem::forget(stderr_fd);
+
+        self.process = Some(process);
+        Ok(())
+    }
+
+    /// Set up direct redirection to a file
+    fn setup_file_redirection(&mut self, output_log: &std::path::Path) -> io::Result<()> {
+        let file = File::create(output_log)?;
+
+        // Redirect stdout and stderr to the file
+        let mut stdout_fd = unsafe { OwnedFd::from_raw_fd(nix::libc::STDOUT_FILENO) };
+        let mut stderr_fd = unsafe { OwnedFd::from_raw_fd(nix::libc::STDERR_FILENO) };
+        dup2(&file, &mut stdout_fd).map_err(|e| {
+            io::Error::new(
+                io::ErrorKind::Other,
+                format!("Failed to redirect stdout to file: {}", e),
+            )
+        })?;
+        dup2(&file, &mut stderr_fd).map_err(|e| {
+            io::Error::new(
+                io::ErrorKind::Other,
+                format!("Failed to redirect stderr to file: {}", e),
+            )
+        })?;
+        std::mem::forget(stdout_fd);
+        std::mem::forget(stderr_fd);
+
+        self.newfd = Some(file);
+        Ok(())
+    }
+
+    /// Manually restore the original stdout/stderr
+    ///
+    /// This is called automatically by Drop, but can be called manually
+    /// if you need to restore output before the CopyOutput is dropped.
+    pub fn restore(&mut self) -> io::Result<()> {
+        if let (Some(old_stdout), Some(old_stderr)) =
+            (self.old_stdout.take(), self.old_stderr.take())
+        {
+            // Restore original stdout and stderr
+            let mut stdout_fd = unsafe { OwnedFd::from_raw_fd(nix::libc::STDOUT_FILENO) };
+            let mut stderr_fd = unsafe { OwnedFd::from_raw_fd(nix::libc::STDERR_FILENO) };
+            dup2(&old_stdout, &mut stdout_fd).map_err(|e| {
+                io::Error::new(
+                    io::ErrorKind::Other,
+                    format!("Failed to restore stdout: {}", e),
+                )
+            })?;
+
+            dup2(&old_stderr, &mut stderr_fd).map_err(|e| {
+                io::Error::new(
+                    io::ErrorKind::Other,
+                    format!("Failed to restore stderr: {}", e),
+                )
+            })?;
+
+            // Don't close stdout/stderr
+            std::mem::forget(stdout_fd);
+            std::mem::forget(stderr_fd);
+            // old_stdout and old_stderr are dropped here, closing the duplicated fds
+            drop(old_stdout);
+            drop(old_stderr);
+        }
+
+        // Clean up tee process or file
+        if self.tee {
+            if let Some(ref mut process) = self.process.take() {
+                process.wait().map_err(|e| {
+                    io::Error::new(
+                        io::ErrorKind::Other,
+                        format!("Failed to wait on tee process: {}", e),
+                    )
+                })?;
+            }
+        } else if let Some(ref mut file) = self.newfd.take() {
+            file.flush().map_err(|e| {
+                io::Error::new(
+                    io::ErrorKind::Other,
+                    format!("Failed to flush output file: {}", e),
+                )
+            })?;
+        }
+
+        Ok(())
     }
 }
 
 impl Drop for CopyOutput {
     fn drop(&mut self) {
-        // Restore original stdout and stderr
-        let mut stdout_fd = unsafe { OwnedFd::from_raw_fd(nix::libc::STDOUT_FILENO) };
-        let mut stderr_fd = unsafe { OwnedFd::from_raw_fd(nix::libc::STDERR_FILENO) };
-        dup2(&self.old_stdout, &mut stdout_fd).expect("Failed to restore stdout");
-        dup2(&self.old_stderr, &mut stderr_fd).expect("Failed to restore stderr");
-        std::mem::forget(stdout_fd); // Don't close stdout/stderr
-        std::mem::forget(stderr_fd);
-
-        // Ensure process or file is cleaned up
-        if self.tee {
-            if let Some(ref mut process) = self.process {
-                process.wait().expect("Failed to wait on tee process");
-            }
-        } else if let Some(ref mut file) = self.newfd {
-            file.flush().expect("Failed to flush output file");
+        // Attempt to restore file descriptors safely
+        // In Drop we can't propagate errors, so we log them instead
+        if let Err(e) = self.restore() {
+            eprintln!(
+                "Warning: Failed to restore file descriptors during drop: {}",
+                e
+            );
+            // Continue with cleanup - don't panic in Drop
         }
     }
 }
+
+#[cfg(test)]
+#[path = "tee_tests.rs"]
+mod tee_tests;

--- a/worker/src/tee_tests.rs
+++ b/worker/src/tee_tests.rs
@@ -1,0 +1,248 @@
+#[cfg(test)]
+mod tests {
+    use crate::tee::CopyOutput;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_copy_output_new_invalid_parent() {
+        let nonexistent_path = std::path::Path::new("/nonexistent/directory/output.log");
+        let result = CopyOutput::new(nonexistent_path, false);
+
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::NotFound);
+        assert!(err.to_string().contains("Parent directory does not exist"));
+    }
+
+    #[test]
+    fn test_copy_output_new_valid_parent() {
+        let temp_dir = TempDir::new().unwrap();
+        let output_path = temp_dir.path().join("test_output.log");
+
+        // Test without tee
+        let result = CopyOutput::new(&output_path, false);
+        assert!(result.is_ok());
+
+        // The file should be created
+        assert!(output_path.exists());
+    }
+
+    #[test]
+    fn test_copy_output_new_root_directory() {
+        // Test with a file in the root directory (which always exists)
+        let temp_dir = TempDir::new().unwrap();
+        let output_path = temp_dir.path().join("output.log");
+
+        let result = CopyOutput::new(&output_path, false);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_copy_output_file_creation() {
+        let temp_dir = TempDir::new().unwrap();
+        let output_path = temp_dir.path().join("test.log");
+
+        // Create CopyOutput which should create the file
+        let _copy_output = CopyOutput::new(&output_path, false).unwrap();
+
+        // Verify file was created
+        assert!(output_path.exists());
+        assert!(output_path.is_file());
+    }
+
+    #[test]
+    fn test_copy_output_manual_restore() {
+        let temp_dir = TempDir::new().unwrap();
+        let output_path = temp_dir.path().join("restore_test.log");
+
+        let mut copy_output = CopyOutput::new(&output_path, false).unwrap();
+
+        // Should be able to restore manually
+        let result = copy_output.restore();
+        assert!(result.is_ok());
+
+        // Second restore should be a no-op (old_stdout/stderr already taken)
+        let result = copy_output.restore();
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_copy_output_drop_cleanup() {
+        let temp_dir = TempDir::new().unwrap();
+        let output_path = temp_dir.path().join("drop_test.log");
+
+        {
+            let _copy_output = CopyOutput::new(&output_path, false).unwrap();
+            // CopyOutput should be dropped here and restore file descriptors
+        }
+
+        // If we get here without panic, Drop succeeded
+        assert!(output_path.exists());
+    }
+
+    #[test]
+    fn test_copy_output_fields() {
+        let temp_dir = TempDir::new().unwrap();
+        let output_path = temp_dir.path().join("fields_test.log");
+
+        // Test tee=false
+        let copy_output = CopyOutput::new(&output_path, false).unwrap();
+        assert!(!copy_output.tee);
+        assert!(copy_output.old_stdout.is_some());
+        assert!(copy_output.old_stderr.is_some());
+        assert!(copy_output.process.is_none());
+        assert!(copy_output.newfd.is_some());
+    }
+
+    #[test]
+    fn test_copy_output_tee_mode_process_spawn_failure() {
+        // This test attempts to use tee mode, but may fail if 'tee' command is not available
+        let temp_dir = TempDir::new().unwrap();
+        let output_path = temp_dir.path().join("tee_test.log");
+
+        let result = CopyOutput::new(&output_path, true);
+
+        // This might succeed or fail depending on system availability of 'tee'
+        match result {
+            Ok(copy_output) => {
+                assert!(copy_output.tee);
+                assert!(copy_output.old_stdout.is_some());
+                assert!(copy_output.old_stderr.is_some());
+                assert!(copy_output.process.is_some());
+                assert!(copy_output.newfd.is_none());
+            }
+            Err(e) => {
+                // Expected on systems without 'tee' command
+                assert!(e.to_string().contains("Failed to spawn tee process"));
+            }
+        }
+    }
+
+    #[test]
+    fn test_copy_output_file_mode_vs_tee_mode() {
+        let temp_dir = TempDir::new().unwrap();
+
+        // Test file mode
+        let file_path = temp_dir.path().join("file_mode.log");
+        let file_copy = CopyOutput::new(&file_path, false).unwrap();
+        assert!(!file_copy.tee);
+        assert!(file_copy.newfd.is_some());
+        assert!(file_copy.process.is_none());
+
+        // Test tee mode (if available)
+        let tee_path = temp_dir.path().join("tee_mode.log");
+        if let Ok(tee_copy) = CopyOutput::new(&tee_path, true) {
+            assert!(tee_copy.tee);
+            assert!(tee_copy.newfd.is_none());
+            assert!(tee_copy.process.is_some());
+        }
+    }
+
+    #[test]
+    fn test_copy_output_with_different_extensions() {
+        let temp_dir = TempDir::new().unwrap();
+
+        // Test various file extensions
+        for ext in &["log", "txt", "out", ""] {
+            let filename = if ext.is_empty() {
+                "output".to_string()
+            } else {
+                format!("output.{}", ext)
+            };
+            let output_path = temp_dir.path().join(filename);
+
+            let result = CopyOutput::new(&output_path, false);
+            assert!(result.is_ok(), "Failed for extension: {}", ext);
+            assert!(output_path.exists());
+        }
+    }
+
+    #[test]
+    fn test_copy_output_nested_directories() {
+        let temp_dir = TempDir::new().unwrap();
+
+        // Create nested directory structure
+        let nested_path = temp_dir.path().join("level1").join("level2");
+        fs::create_dir_all(&nested_path).unwrap();
+
+        let output_path = nested_path.join("nested_output.log");
+        let result = CopyOutput::new(&output_path, false);
+
+        assert!(result.is_ok());
+        assert!(output_path.exists());
+    }
+
+    #[test]
+    fn test_copy_output_existing_file_overwrite() {
+        let temp_dir = TempDir::new().unwrap();
+        let output_path = temp_dir.path().join("existing.log");
+
+        // Create existing file with content
+        fs::write(&output_path, "existing content").unwrap();
+        assert_eq!(
+            fs::read_to_string(&output_path).unwrap(),
+            "existing content"
+        );
+
+        // CopyOutput should overwrite it (File::create truncates)
+        let _copy_output = CopyOutput::new(&output_path, false).unwrap();
+
+        // File should still exist but may be truncated
+        assert!(output_path.exists());
+    }
+
+    // Test the internal state management
+    #[test]
+    fn test_copy_output_state_transitions() {
+        let temp_dir = TempDir::new().unwrap();
+        let output_path = temp_dir.path().join("state_test.log");
+
+        let mut copy_output = CopyOutput::new(&output_path, false).unwrap();
+
+        // Initial state
+        assert!(copy_output.old_stdout.is_some());
+        assert!(copy_output.old_stderr.is_some());
+
+        // After restore
+        copy_output.restore().unwrap();
+        assert!(copy_output.old_stdout.is_none());
+        assert!(copy_output.old_stderr.is_none());
+    }
+
+    #[test]
+    fn test_copy_output_error_messages() {
+        // Test error message formatting for invalid paths
+        let result = CopyOutput::new(std::path::Path::new("/invalid/path/file.log"), false);
+
+        assert!(result.is_err());
+        let error_message = result.unwrap_err().to_string();
+        assert!(error_message.contains("Parent directory does not exist"));
+        assert!(error_message.contains("/invalid/path"));
+    }
+
+    // This test ensures the CopyOutput properly implements Send + Sync if needed
+    #[test]
+    fn test_copy_output_thread_safety() {
+        fn assert_send<T: Send>() {}
+        fn assert_sync<T: Sync>() {}
+
+        // CopyOutput contains raw file descriptors, so it may not be Send/Sync
+        // This documents the current behavior
+        // assert_send::<CopyOutput>();
+        // assert_sync::<CopyOutput>();
+    }
+
+    #[test]
+    fn test_copy_output_memory_safety() {
+        let temp_dir = TempDir::new().unwrap();
+        let output_path = temp_dir.path().join("memory_test.log");
+
+        // Test that creating and dropping multiple CopyOutput instances works
+        for i in 0..10 {
+            let path = temp_dir.path().join(format!("test_{}.log", i));
+            let _copy_output = CopyOutput::new(&path, false).unwrap();
+            // Each one should clean up properly when dropped
+        }
+    }
+}


### PR DESCRIPTION
Cleanup moves from Drop into an explicit restore() so callers can observe errors; dup2/wait/flush no longer panic.