### PR TITLE
ci: Cache buildah layers and cancel superseded PR runs

### DIFF
--- a/.github/workflows/containers.yaml
+++ b/.github/workflows/containers.yaml
@@ -7,6 +7,10 @@ name: Containers - Build and push images
   schedule:
     - cron: '0 6 * * *'  # Daily 6AM UTC build
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build:
     name: Build and Push
@@ -51,23 +55,6 @@ jobs:
             exit 1
           fi
           echo "TAGS=${TAGS}" | tee -a $GITHUB_ENV
-      - name: Build ${{ matrix.dockerfile_suffix }} image
-        id: build-image
-        uses: redhat-actions/buildah-build@v2
-        with:
-          containerfiles: "Dockerfile_${{ matrix.dockerfile_suffix }}"
-          image: |
-            ghcr.io/${{ github.repository }}/${{ matrix.dockerfile_suffix }}
-          tags: ${{ env.TAGS }}
-
-      - name: Test ${{ matrix.dockerfile_suffix }} image
-        run: |
-          set -x
-          tag="$( echo ${{ env.TAGS }} | awk '{print $1}' )"
-          podman run \
-            ghcr.io/${{ github.repository }}/\
-          ${{ matrix.dockerfile_suffix }}:${tag} \
-            --help
 
       - name: Login to GitHub Packages (ghcr.io)
         if: |
@@ -77,6 +64,42 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Assemble buildah cache args
+        env:
+          REPO: ${{ github.repository }}
+          SUFFIX: ${{ matrix.dockerfile_suffix }}
+          EVENT: ${{ github.event_name }}
+        run: |
+          CACHE_REPO="ghcr.io/${REPO}/${SUFFIX}-buildcache"
+          {
+            echo "BUILDAH_CACHE_ARGS<<EOF"
+            echo "--cache-from=${CACHE_REPO}"
+            if [ "${EVENT}" != "pull_request" ]; then
+              echo "--cache-to=${CACHE_REPO}"
+            fi
+            echo "EOF"
+          } >> "$GITHUB_ENV"
+
+      - name: Build ${{ matrix.dockerfile_suffix }} image
+        id: build-image
+        uses: redhat-actions/buildah-build@v2
+        with:
+          containerfiles: "Dockerfile_${{ matrix.dockerfile_suffix }}"
+          image: |
+            ghcr.io/${{ github.repository }}/${{ matrix.dockerfile_suffix }}
+          tags: ${{ env.TAGS }}
+          layers: true
+          extra-args: ${{ env.BUILDAH_CACHE_ARGS }}
+
+      - name: Test ${{ matrix.dockerfile_suffix }} image
+        run: |
+          set -x
+          tag="$( echo ${{ env.TAGS }} | awk '{print $1}' )"
+          podman run \
+            ghcr.io/${{ github.repository }}/\
+          ${{ matrix.dockerfile_suffix }}:${tag} \
+            --help
 
       - name: >
           Push ${{ env.container }} image to

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -7,6 +7,10 @@ name: Linting
   schedule:
     - cron: '0 6 * * *'    # Daily 6AM UTC build
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   yamllint:
     name: YAML Lint

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -7,6 +7,10 @@ name: Python package - Check, build and test
   schedule:
     - cron: '0 6 * * *'    # Daily 6AM UTC build
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   # Standard packages: ./CONTRIBUTING.md (also ./Dockerfile_*)
   #   Dirty hack for the lack of YAML anchors

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -5,6 +5,10 @@ name: Rust build
   push:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   CARGO_TERM_COLOR: always
 

--- a/.github/workflows/sql.yaml
+++ b/.github/workflows/sql.yaml
@@ -9,6 +9,10 @@ name: SQL - Check database
   schedule:
     - cron: '0 6 * * *'  # Daily 6AM UTC build
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build:
     name: Test SQL


### PR DESCRIPTION
Add registry-backed layer caching (--cache-from/--cache-to against `<image>-buildcache` on ghcr.io) with `layers: true` to the matrix container build. On PRs we only read from the cache; only push and schedule events populate it, to avoid PR-poisoned cache content and permission issues on fork PRs. Move the ghcr.io login above the build step so `--cache-to` has credentials when it needs them.

Also add a `concurrency` group to every workflow that cancels in-progress runs on the same ref when a new push arrives on a PR, while leaving main/tag/schedule builds untouched so publishing isn't interrupted.