### PR TITLE
Make Python service Dockerfiles multi-stage

### DIFF
--- a/Dockerfile_archive
+++ b/Dockerfile_archive
@@ -26,12 +26,38 @@ RUN apt-get update --yes \
         libapt-pkg-dev \
         python3-gpg \
         python3-pip \
+        python3-venv \
  && apt-get clean
+
+RUN python3 -m venv --system-site-packages /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
 
 COPY . /code
 
-RUN pip3 install --break-system-packages --upgrade "/code[gcp,archive]" \
+RUN pip3 install --upgrade "/code[gcp,archive]" \
  && rm -rf /code
+
+FROM docker.io/debian:testing-slim
+MAINTAINER Jelmer Vernooij <jelmer@jelmer.uk>
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update --yes \
+ && apt-get install --yes --no-install-recommends \
+        auto-apt-proxy \
+ && apt-get upgrade --yes \
+ && apt-get satisfy --yes --no-install-recommends \
+        ca-certificates \
+        dpkg-dev \
+        git \
+        libssl3 \
+        libzstd1 \
+        python3-gpg \
+        python3 \
+ && apt-get clean
+
+COPY --from=build /opt/venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
 
 EXPOSE 9914
 

--- a/Dockerfile_auto_upload
+++ b/Dockerfile_auto_upload
@@ -22,12 +22,35 @@ RUN apt-get update --yes \
         protobuf-compiler \
        ## Extra packages
         python3-pip \
+        python3-venv \
  && apt-get clean
+
+RUN python3 -m venv --system-site-packages /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
 
 COPY . /code
 
-RUN pip3 install --break-system-packages --upgrade "/code[gcp,auto-upload]" \
+RUN pip3 install --upgrade "/code[gcp,auto-upload]" \
  && rm -rf /code
+
+FROM docker.io/debian:testing-slim
+MAINTAINER Jelmer Vernooij <jelmer@jelmer.uk>
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update --yes \
+ && apt-get install --yes --no-install-recommends \
+        auto-apt-proxy \
+ && apt-get upgrade --yes \
+ && apt-get satisfy --yes --no-install-recommends \
+        ca-certificates \
+        libssl3 \
+        libzstd1 \
+        python3 \
+ && apt-get clean
+
+COPY --from=build /opt/venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
 
 EXPOSE 9933
 

--- a/Dockerfile_bzr_store
+++ b/Dockerfile_bzr_store
@@ -23,12 +23,36 @@ RUN apt-get update --yes \
        ## Extra packages
         python3-gpg \
         python3-pip \
+        python3-venv \
  && apt-get clean
+
+RUN python3 -m venv --system-site-packages /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
 
 COPY . /code
 
-RUN pip3 install --break-system-packages --upgrade "/code[gcp,bzr-store]" \
+RUN pip3 install --upgrade "/code[gcp,bzr-store]" \
  && rm -rf /code
+
+FROM docker.io/debian:testing-slim
+MAINTAINER Jelmer Vernooij <jelmer@jelmer.uk>
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update --yes \
+ && apt-get install --yes --no-install-recommends \
+        auto-apt-proxy \
+ && apt-get upgrade --yes \
+ && apt-get satisfy --yes --no-install-recommends \
+        ca-certificates \
+        libssl3 \
+        libzstd1 \
+        python3-gpg \
+        python3 \
+ && apt-get clean
+
+COPY --from=build /opt/venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
 
 VOLUME /bzr
 

--- a/Dockerfile_differ
+++ b/Dockerfile_differ
@@ -23,12 +23,36 @@ RUN apt-get update --yes \
        ## Extra packages
         python3-gpg \
         python3-pip \
+        python3-venv \
  && apt-get clean
+
+RUN python3 -m venv --system-site-packages /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
 
 COPY . /code
 
-RUN pip3 install --break-system-packages --upgrade "/code[gcp,differ]" \
+RUN pip3 install --upgrade "/code[gcp,differ]" \
  && rm -rf /code
+
+FROM docker.io/debian:testing-slim
+MAINTAINER Jelmer Vernooij <jelmer@jelmer.uk>
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update --yes \
+ && apt-get install --yes --no-install-recommends \
+        auto-apt-proxy \
+ && apt-get upgrade --yes \
+ && apt-get satisfy --yes --no-install-recommends \
+        ca-certificates \
+        libssl3 \
+        libzstd1 \
+        python3-gpg \
+        python3 \
+ && apt-get clean
+
+COPY --from=build /opt/venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
 
 EXPOSE 9920
 

--- a/Dockerfile_git_store
+++ b/Dockerfile_git_store
@@ -24,12 +24,37 @@ RUN apt-get update --yes \
         git \
         python3-gpg \
         python3-pip \
+        python3-venv \
  && apt-get clean
+
+RUN python3 -m venv --system-site-packages /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
 
 COPY . /code
 
-RUN pip3 install --break-system-packages --upgrade "/code[gcp,git-store]" \
+RUN pip3 install --upgrade "/code[gcp,git-store]" \
  && rm -rf /code
+
+FROM docker.io/debian:testing-slim
+MAINTAINER Jelmer Vernooij <jelmer@jelmer.uk>
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update --yes \
+ && apt-get install --yes --no-install-recommends \
+        auto-apt-proxy \
+ && apt-get upgrade --yes \
+ && apt-get satisfy --yes --no-install-recommends \
+        ca-certificates \
+        git \
+        libssl3 \
+        libzstd1 \
+        python3-gpg \
+        python3 \
+ && apt-get clean
+
+COPY --from=build /opt/venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
 
 VOLUME /git
 

--- a/Dockerfile_publish
+++ b/Dockerfile_publish
@@ -23,12 +23,36 @@ RUN apt-get update --yes \
        ## Extra packages
         python3-gpg \
         python3-pip \
+        python3-venv \
  && apt-get clean
+
+RUN python3 -m venv --system-site-packages /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
 
 COPY . /code
 
-RUN pip3 install --break-system-packages --upgrade "/code[gcp,publish]" \
+RUN pip3 install --upgrade "/code[gcp,publish]" \
  && rm -rf /code
+
+FROM docker.io/debian:testing-slim
+MAINTAINER Jelmer Vernooij <jelmer@jelmer.uk>
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update --yes \
+ && apt-get install --yes --no-install-recommends \
+        auto-apt-proxy \
+ && apt-get upgrade --yes \
+ && apt-get satisfy --yes --no-install-recommends \
+        ca-certificates \
+        libssl3 \
+        libzstd1 \
+        python3-gpg \
+        python3 \
+ && apt-get clean
+
+COPY --from=build /opt/venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
 
 EXPOSE 9912
 

--- a/Dockerfile_runner
+++ b/Dockerfile_runner
@@ -26,12 +26,38 @@ RUN apt-get update --yes \
         libapt-pkg-dev \
         python3-gpg \
         python3-pip \
+        python3-venv \
  && apt-get clean
+
+RUN python3 -m venv --system-site-packages /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
 
 COPY . /code
 
-RUN pip3 install --break-system-packages --upgrade "/code[gcp,runner]" \
+RUN pip3 install --upgrade "/code[gcp,runner]" \
  && rm -rf /code
+
+FROM docker.io/debian:testing-slim
+MAINTAINER Jelmer Vernooij <jelmer@jelmer.uk>
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update --yes \
+ && apt-get install --yes --no-install-recommends \
+        auto-apt-proxy \
+ && apt-get upgrade --yes \
+ && apt-get satisfy --yes --no-install-recommends \
+        ca-certificates \
+        dpkg-dev \
+        git \
+        libssl3 \
+        libzstd1 \
+        python3-gpg \
+        python3 \
+ && apt-get clean
+
+COPY --from=build /opt/venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
 
 EXPOSE 9911
 

--- a/Dockerfile_site
+++ b/Dockerfile_site
@@ -24,18 +24,42 @@ RUN apt-get update --yes \
         pkg-config \
         protobuf-compiler \
        ## Extra packages
+        python3-gpg \
+        python3-pip \
+        python3-venv \
+ && apt-get clean
+
+RUN python3 -m venv --system-site-packages /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+
+COPY . /code
+
+RUN pip3 install --upgrade "/code[gcp,site]" \
+ && rm -rf /code
+
+FROM docker.io/debian:testing-slim
+MAINTAINER Jelmer Vernooij <jelmer@jelmer.uk>
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update --yes \
+ && apt-get install --yes --no-install-recommends \
+        auto-apt-proxy \
+ && apt-get upgrade --yes \
+ && apt-get satisfy --yes --no-install-recommends \
+        ca-certificates \
         libjs-chart.js \
         libjs-jquery-datatables \
         libjs-jquery-typeahead \
         libjs-moment \
+        libssl3 \
+        libzstd1 \
         python3-gpg \
-        python3-pip \
+        python3 \
  && apt-get clean
 
-COPY . /code
-
-RUN pip3 install --break-system-packages --upgrade "/code[gcp,site]" \
- && rm -rf /code
+COPY --from=build /opt/venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
 
 EXPOSE 8080
 


### PR DESCRIPTION
Split the eight single-stage Python service Dockerfiles (archive, auto_upload, bzr_store, differ, git_store, publish, runner, site) into a build stage and a runtime stage. The build stage installs compilers, headers and pip, then installs the janitor package into a venv at /opt/venv. The runtime stage copies /opt/venv from the build stage and installs only the runtime apt packages needed to load the compiled Rust extensions (libssl3, libzstd1) plus per-service extras (python3-gpg, dpkg-dev, git, libjs-*).

The archive image shrinks from ~2.82 GB to ~674 MB.