### PR TITLE
containers: Publish under vars.GHCR_OWNER when set

### DIFF
--- a/.github/workflows/containers.yaml
+++ b/.github/workflows/containers.yaml
@@ -16,6 +16,11 @@ jobs:
     name: Build and Push
     # https://github.com/actions/runner-images
     runs-on: ubuntu-latest
+    # Publish under vars.GHCR_OWNER when set (see issue #1329: janitor-team
+    # org lacks package-creation permission, so we override to "jelmer"),
+    # else fall back to the current repository owner (works for forks).
+    env:
+      GHCR_OWNER: ${{ vars.GHCR_OWNER || github.repository_owner }}
 
     strategy:
       matrix:
@@ -62,16 +67,16 @@ jobs:
         uses: redhat-actions/podman-login@v1
         with:
           registry: ghcr.io
-          username: ${{ github.repository_owner }}
+          username: ${{ env.GHCR_OWNER }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Assemble buildah cache args
         env:
-          REPO: ${{ github.repository }}
+          REPO_NAME: ${{ github.event.repository.name }}
           SUFFIX: ${{ matrix.dockerfile_suffix }}
           EVENT: ${{ github.event_name }}
         run: |
-          CACHE_REPO="ghcr.io/${REPO}/${SUFFIX}-buildcache"
+          CACHE_REPO="ghcr.io/${GHCR_OWNER}/${REPO_NAME}/${SUFFIX}-buildcache"
           {
             echo "BUILDAH_CACHE_ARGS<<EOF"
             echo "--cache-from=${CACHE_REPO}"
@@ -87,7 +92,7 @@ jobs:
         with:
           containerfiles: "Dockerfile_${{ matrix.dockerfile_suffix }}"
           image: |
-            ghcr.io/${{ github.repository }}/${{ matrix.dockerfile_suffix }}
+            ghcr.io/${{ env.GHCR_OWNER }}/${{ github.event.repository.name }}/${{ matrix.dockerfile_suffix }}
           tags: ${{ env.TAGS }}
           layers: true
           extra-args: ${{ env.BUILDAH_CACHE_ARGS }}
@@ -97,13 +102,13 @@ jobs:
           set -x
           tag="$( echo ${{ env.TAGS }} | awk '{print $1}' )"
           podman run \
-            ghcr.io/${{ github.repository }}/\
+            ghcr.io/${{ env.GHCR_OWNER }}/${{ github.event.repository.name }}/\
           ${{ matrix.dockerfile_suffix }}:${tag} \
             --help
 
       - name: >
           Push ${{ env.container }} image to
-          https://github.com/${{ github.repository_owner }}?\
+          https://github.com/${{ env.GHCR_OWNER }}?\
           tab=packages&repo_name=${{ github.event.repository.name }}
         if: |
           github.event_name != 'pull_request'
@@ -112,5 +117,5 @@ jobs:
           image: ${{ steps.build-image.outputs.image }}
           tags: ${{ steps.build-image.outputs.tags }}
           registry: ghcr.io
-          username: ${{ github.repository_owner }}
+          username: ${{ env.GHCR_OWNER }}
           password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/containers.yaml
+++ b/.github/workflows/containers.yaml
@@ -71,7 +71,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ env.GHCR_OWNER }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.GHCR_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Assemble buildah cache args
         env:
@@ -117,4 +117,4 @@ jobs:
           tags: ${{ steps.build-image.outputs.tags }}
           registry: ghcr.io
           username: ${{ env.GHCR_OWNER }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.GHCR_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/containers.yaml
+++ b/.github/workflows/containers.yaml
@@ -21,6 +21,9 @@ jobs:
     # else fall back to the current repository owner (works for forks).
     env:
       GHCR_OWNER: ${{ vars.GHCR_OWNER || github.repository_owner }}
+      IMAGE_BASE: >-
+        ghcr.io/${{ vars.GHCR_OWNER || github.repository_owner
+        }}/${{ github.event.repository.name }}
 
     strategy:
       matrix:
@@ -72,11 +75,10 @@ jobs:
 
       - name: Assemble buildah cache args
         env:
-          REPO_NAME: ${{ github.event.repository.name }}
           SUFFIX: ${{ matrix.dockerfile_suffix }}
           EVENT: ${{ github.event_name }}
         run: |
-          CACHE_REPO="ghcr.io/${GHCR_OWNER}/${REPO_NAME}/${SUFFIX}-buildcache"
+          CACHE_REPO="${IMAGE_BASE}/${SUFFIX}-buildcache"
           {
             echo "BUILDAH_CACHE_ARGS<<EOF"
             echo "--cache-from=${CACHE_REPO}"
@@ -91,8 +93,7 @@ jobs:
         uses: redhat-actions/buildah-build@v2
         with:
           containerfiles: "Dockerfile_${{ matrix.dockerfile_suffix }}"
-          image: |
-            ghcr.io/${{ env.GHCR_OWNER }}/${{ github.event.repository.name }}/${{ matrix.dockerfile_suffix }}
+          image: ${{ env.IMAGE_BASE }}/${{ matrix.dockerfile_suffix }}
           tags: ${{ env.TAGS }}
           layers: true
           extra-args: ${{ env.BUILDAH_CACHE_ARGS }}
@@ -101,10 +102,8 @@ jobs:
         run: |
           set -x
           tag="$( echo ${{ env.TAGS }} | awk '{print $1}' )"
-          podman run \
-            ghcr.io/${{ env.GHCR_OWNER }}/${{ github.event.repository.name }}/\
-          ${{ matrix.dockerfile_suffix }}:${tag} \
-            --help
+          suffix="${{ matrix.dockerfile_suffix }}"
+          podman run "${{ env.IMAGE_BASE }}/${suffix}:${tag}" --help
 
       - name: >
           Push ${{ env.container }} image to


### PR DESCRIPTION
The repo transfer to janitor-team broke ghcr.io pushes: the org lacks package-creation permission, so `github.repository_owner`-derived paths hit "installation not allowed to Create organization package".

Introduce a single `GHCR_OWNER` env var, defaulted to `vars.GHCR_OWNER || github.repository_owner`, and use it for the image path, login username, and push URL. Setting the repo variable `GHCR_OWNER=jelmer` routes publishes back to the pre-existing `ghcr.io/jelmer/janitor/*` packages; forks fall back to their own owner automatically.

Fixes #1329