### PR TITLE
site/cupboard: return 404 from /cupboard/evaluate/{run_id} for unknown run

### DIFF
--- a/py/janitor/site/cupboard/review.py
+++ b/py/janitor/site/cupboard/review.py
@@ -5,7 +5,7 @@ from asyncio import TimeoutError
 
 import aiozipkin
 import asyncpg
-from aiohttp import ClientConnectorError, ClientResponseError
+from aiohttp import ClientConnectorError, ClientResponseError, web
 from breezy.revision import NULL_REVISION
 
 from janitor import state
@@ -120,6 +120,8 @@ async def generate_evaluate(
             "finish_time, value, command, suite AS campaign FROM run WHERE id = $1",
             run_id,
         )
+    if run is None:
+        raise web.HTTPNotFound(text=f"No run with id {run_id!r}")
 
     async def show_diff(role):
         try:

--- a/tests/test_cupboard.py
+++ b/tests/test_cupboard.py
@@ -17,6 +17,7 @@
 
 from datetime import datetime, timedelta
 
+import pytest
 from aiohttp import web
 from jinja2 import Environment
 from yarl import URL
@@ -315,6 +316,13 @@ async def test_run_redirect_unknown_run_returns_404(aiohttp_client, db):
     client = await create_client(aiohttp_client, db)
     resp = await client.get("/cupboard/run/nonexistent/", allow_redirects=False)
     assert resp.status == 404
+
+
+async def test_evaluate_unknown_run_returns_404(db):
+    from janitor.site.cupboard.review import generate_evaluate
+
+    with pytest.raises(web.HTTPNotFound):
+        await generate_evaluate(db, {}, None, None, "nonexistent", None)
 
 
 ADMIN_USER = {"email": "admin@example.com", "groups": []}


### PR DESCRIPTION
generate_evaluate() used the fetchrow() result for run_id unconditionally. asyncpg returns None when no row matches, so any nonexistent run_id crashed with TypeError: 'NoneType' object is not subscriptable instead of a 404, matching the existing 404 handling for the same case elsewhere in this file.