### PR TITLE
git_store: dont crash when the client disconnects right after reading

### DIFF
--- a/py/janitor/git_store.py
+++ b/py/janitor/git_store.py
@@ -385,13 +385,20 @@ async def cgit_backend(request: web.Request) -> web.Response:
                 while chunk:
                     try:
                         await response.write(chunk)
+                    except ConnectionResetError:
+                        # Client already got what it wanted and hung up -
+                        # nothing left to write, nothing to report.
+                        with suppress(ProcessLookupError):
+                            p.kill()
+                        return response
                     except BaseException:
                         with suppress(ProcessLookupError):
                             p.kill()
                         raise
                     chunk = await p.stdout.read(GIT_BACKEND_CHUNK_SIZE)  # type: ignore
 
-                await response.write_eof()
+                with suppress(ConnectionResetError):
+                    await response.write_eof()
 
                 return response
 
@@ -459,9 +466,9 @@ async def dulwich_refs(request: web.Request) -> web.StreamResponse:
 
         await asyncio.to_thread(handler.handle)
 
-        await response.write(out.getvalue())
-
-        await response.write_eof()
+        with suppress(ConnectionResetError):
+            await response.write(out.getvalue())
+            await response.write_eof()
 
         return response
 
@@ -509,9 +516,9 @@ async def dulwich_service(request: web.Request) -> web.StreamResponse:
 
         await asyncio.to_thread(handle)
 
-        await response.write(outf.getvalue())
-
-        await response.write_eof()
+        with suppress(ConnectionResetError):
+            await response.write(outf.getvalue())
+            await response.write_eof()
         return response
 
 


### PR DESCRIPTION
A well-behaved git client can legitimately close its side of the connection as soon as it has read everything it wants, before the server finishes writing. All three of git_store's response-writing paths - the subprocess-streaming loop in cgit_backend, and dulwich_service's smart-HTTP handler plus its refs-advertisement counterpart - could raise ConnectionResetError (aiohttp's ClientConnectionResetError is a real subclass) from a write() or write_eof() call that was unhandled, surfacing as a server error instead of a clean, silent completion.

Reproduced directly against a real running instance: opening a branch through breezy's git+ssh transport hits the refs/service handlers' crash, and a real publish attempt hits cgit_backends's - dulwich reads the pack data it needs mid-stream and hangs up, git_store then fails trying to write the next chunk to the already-closing transport.

(rescued from caretaker-janitor commit)