### PR TITLE
Require admin for reprocess logs and explicit publish modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,13 @@ Several docker images are provided
  * ghcr.io/jelmer/janitor/bzr_store - storage for Bazaar
  * ghcr.io/jelmer/janitor/worker - Base for workers
 
+Usage
+=====
+
+See [docs/usage.md](docs/usage.md) for a guide to using an instance,
+whether you're browsing as a visitor, checking on your own package,
+setting up a new instance, or administering an existing one.
+
 Contributing
 ============
 

--- a/docs/production.md
+++ b/docs/production.md
@@ -97,6 +97,12 @@ unset:
 For a Janitor instance, you probably want a custom website in combination with
 the Janitor API. See the existing instances for inspiration.
 
+Once an instance is running, see [roles.md](roles.md) for what its
+`oauth2_provider.qa_reviewer_group` and `admin_group` config actually
+grant on the web UI, and [usage.md](usage.md) for a guide to using an
+instance by audience - visitor, package maintainer, distro/OS
+maintainer, or admin.
+
 ## Registering workers
 
 Workers authenticate to the site with a name and password stored in the `worker`

--- a/docs/roles.md
+++ b/docs/roles.md
@@ -1,0 +1,103 @@
+# Access control on the Janitor web UI
+
+The cupboard recognizes four levels of access: anonymous visitors,
+logged-in users, the QA reviewer group, and the admin group. Reviewer
+and admin membership come from the OAuth2 identity provider configured
+in the `oauth2_provider` block in `janitor.conf` (see
+`janitor.conf.example`), specifically its `qa_reviewer_group` and
+`admin_group` fields. Those fields name a group in the identity
+provider's own group list, for example a GitHub org team or a GitLab
+group - the site keeps no user database of its own, so granting or
+revoking reviewer or admin access means adding or removing someone from
+that group on the identity provider itself, not anything done inside
+janitor.
+
+## How access is determined
+
+Access level follows from whether you are logged in and, if so, which
+groups the identity provider currently reports for your account,
+checked again on every request. An anonymous visitor has no session at
+all; logging in through the OAuth2 provider establishes one, and QA
+reviewer and admin status are then a matter of group membership as the
+identity provider reports it, not something tracked or remembered
+independently.
+
+Leaving `admin_group` or `qa_reviewer_group` unset in `janitor.conf`
+grants that role to every logged-in user - the group check only
+restricts access once a group is actually configured; there is no
+"nobody qualifies" default.
+
+## Anonymous / guest
+
+An anonymous visitor can browse the campaign home and per-campaign
+pages, candidate listings, per-codebase and per-run pages, and the
+whole cupboard section, including the review queue itself - none of
+it requires a session.
+
+An anonymous visitor can trigger a publish attempt for a codebase
+using the "Publish now" button - it has no login or admin check
+either.
+
+## Logged in, no group membership
+
+Logging in through the OAuth2 flow does not by itself unlock any
+additional pages. The one behavioral change is on the review form shown
+on a run page: anonymous visitors see the same form, but clicking a
+verdict button while logged out gets a 401 and redirects to `/login`,
+while a logged-in user's click succeeds and the verdict is recorded -
+accepted from any logged-in user, regardless of group membership.
+Whether it also takes effect - forwarded to the runner as a publish
+status update - depends on whether you belong to the QA reviewer group,
+so a plain logged-in user's "approve" is recorded but does not by
+itself publish anything.
+
+## QA reviewer group (`qa_reviewer_group`)
+
+Reviewer membership changes what a submitted verdict does, not who is
+allowed to submit one. A verdict other than "abstain" from a reviewer is
+forwarded to the runner as a publish status update; a non-reviewer's
+verdict of any kind is stored as a comment and never changes whether the
+run publishes.
+
+Reviewer group membership also affects one piece of UI: on a successful
+run, the Reviews section is shown to a reviewer even before any review
+exists, so they see a place to leave one, while other visitors only see
+it once a review has been submitted.
+
+## Admin group (`admin_group`)
+
+Admin is the only role enforced server-side beyond being logged in.
+Every one of the following requires admin group membership and returns
+401 to anyone else:
+
+* `POST /api/merge-proposal` - change a merge proposal's status
+  (closed, abandoned, applied, rejected).
+* `POST /api/active-runs/{run_id}/kill` - kill a running worker job.
+* `POST /cupboard/api/mass-reschedule` - bulk-reschedule runs matching
+  a result code and description regex.
+* `POST /cupboard/api/run/{run_id}/reprocess-logs` and
+  `POST /cupboard/api/reprocess-logs` - reprocess stored build logs for
+  one run or in bulk.
+* `POST /cupboard/api/publish/autopublish` and
+  `POST /cupboard/api/publish/scan` - trigger an autopublish pass or a
+  merge-proposal status rescan.
+* `GET /cupboard/api/workers`, `POST /cupboard/api/workers`, and
+  `DELETE /cupboard/api/workers/{name}` - list registered workers,
+  register a new one with a generated password, and remove one.
+
+Templates hide the corresponding controls from non-admins: the Kill
+button and Admin column in the queue, the mass-reschedule form on the
+result-code and never-processed pages, the Refresh Merge Proposal
+Status and Automatically Publish buttons on the publish history page,
+the Reprocess Logs sidebar link, and the closed/abandoned/applied/
+rejected status dropdown on a merge proposal page.
+
+Two of these controls are UI-only, without a matching server-side check:
+`GET /cupboard/reprocess-logs` itself is not admin-gated - only the two
+POST endpoints above are, so a non-admin can load the empty form, they
+just cannot submit it - and the extra publish modes `publish_buttons`
+exposes to an admin ("Create fork with changes", "Push", "Create merge
+proposal") all post to the same unguarded
+`POST /{campaign}/c/{codebase}/publish` as the plain "Publish now"
+button. Nothing on the server stops a request that already knows the
+`mode` parameter from using them without being an admin.

--- a/docs/roles.md
+++ b/docs/roles.md
@@ -92,12 +92,3 @@ Status and Automatically Publish buttons on the publish history page,
 the Reprocess Logs sidebar link, and the closed/abandoned/applied/
 rejected status dropdown on a merge proposal page.
 
-Two of these controls are UI-only, without a matching server-side check:
-`GET /cupboard/reprocess-logs` itself is not admin-gated - only the two
-POST endpoints above are, so a non-admin can load the empty form, they
-just cannot submit it - and the extra publish modes `publish_buttons`
-exposes to an admin ("Create fork with changes", "Push", "Create merge
-proposal") all post to the same unguarded
-`POST /{campaign}/c/{codebase}/publish` as the plain "Publish now"
-button. Nothing on the server stops a request that already knows the
-`mode` parameter from using them without being an admin.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,101 @@
+# Using a Janitor instance
+
+Janitor is a platform that runs automated code changes ("campaigns")
+across a set of source repositories and tracks the results on a web
+site. This page orients four different kinds of visitor toward the parts
+of the project relevant to them. It does not repeat what is documented
+elsewhere; it points at the real pages and files.
+
+There are several running instances, listed in the top-level
+[README.md](../README.md): the [Debian Janitor](https://janitor.debian.net/),
+the [Kali Janitor](https://janitor.kali.org/), and
+[Scruffy](https://www.scruffy.dev/) for upstream projects. Everything
+below applies to any of them, and to a self-hosted instance.
+
+## Browsing as a visitor
+
+No account is required to look around. From an instance's home page
+(`/`), each campaign gets its own page (`/{campaign}/`) listing the kind
+of change it makes and linking to its candidates
+(`/{campaign}/candidates`) - the repositories a campaign might still run
+against. A specific repository's page (`/{campaign}/c/{codebase}/`) shows
+its run history for that campaign.
+
+`/cupboard/` is the instance's internal status area: the processing
+queue, run history, worker list, result-code breakdowns, publish
+history, and the merge-proposal review queue. All of it is readable
+without logging in; see [roles.md](roles.md) for exactly what changes
+once you do log in.
+
+[glossary.md](glossary.md) defines the recurring terms (codebase,
+campaign, candidate, run, and so on) used across this page and the rest
+of the docs.
+
+## Checking on your own package as a maintainer
+
+If a Janitor instance already covers a package or repository you
+maintain, its per-codebase page (`/{campaign}/c/{codebase}/`) is the
+place to check what the instance has tried, and its most recent run for
+a codebase is linked from there. From a run's own page you can see the
+diff, the build log, and - if the change is ready to go out - a "Publish
+now" button; see [roles.md](roles.md) for who else can act on a run and
+under what conditions.
+
+Runs also link back to any merge proposal the janitor opened, so if a
+change was proposed against your repository, following it from the run
+page is the most direct route back to it.
+
+If a codebase you maintain is not covered yet, or you think a campaign
+should behave differently against it, that is a question for the
+specific instance's own configuration and operators (see below), not
+something this repository controls per-package.
+
+## Running your own instance for a distro or OS
+
+Setting up an instance means deploying the janitor's own services -
+publisher, runner, one or more workers, archiver, differ, VCS store(s),
+and the site - against your own set of repositories and campaigns.
+Start with:
+
+* [production.md](production.md) for deployment: prebuilt containers,
+  building them yourself, and general shape of an instance.
+* [Dockerfiles_.md](Dockerfiles_.md) for what each service's container
+  image provides.
+* [structure.md](structure.md) for the top-level scripts and where admin
+  tooling lives versus what an ordinary user can run.
+* [flow.md](flow.md) for how package metadata and candidates get into
+  the system in the first place, and how scheduling works from there.
+* [roles.md](roles.md) for the `oauth2_provider` config in
+  `janitor.conf.example` that controls who gets reviewer or admin access
+  on your instance's site once it's running.
+* `devnotes/adding-a-new-campaign.rst` for writing the codemod script
+  and campaign definition behind a new kind of change.
+* `devnotes/overview.rst` for how the services talk to each other and
+  which of their APIs are meant to be public versus internal-only.
+
+The [README.md](../README.md) Design section has a short description of
+each permanently running job and how they fit together before you dive
+into any one of them.
+
+## Administering an existing instance
+
+If you already operate an instance, day-to-day admin actions live in
+`/cupboard/` and require being in the `admin_group` configured in your
+`oauth2_provider` block: killing a stuck worker run, reprocessing stored
+build logs, mass-rescheduling runs matching a result code, forcing an
+autopublish pass or a merge-proposal status rescan, and setting a merge
+proposal's terminal status by hand. [roles.md](roles.md) lists each of
+these with the exact route it calls, including two cases where the
+admin-only control in the UI is not backed by an equivalent server-side
+check.
+
+The `qa_reviewer_group` in the same config block controls whose review
+verdicts on `/cupboard/review` actually change a run's publish status,
+as opposed to being recorded without effect; also covered in
+[roles.md](roles.md).
+
+For redeploying, upgrading, or reconfiguring the services themselves,
+[production.md](production.md) and [Dockerfiles_.md](Dockerfiles_.md)
+remain the reference; [CONTRIBUTING.md](../CONTRIBUTING.md) covers
+setting up a development checkout if you need to patch the janitor
+itself rather than just its configuration.

--- a/py/janitor/site/api.py
+++ b/py/janitor/site/api.py
@@ -63,6 +63,8 @@ async def handle_publish(request):
     mode = post.get("mode")
     if mode not in (None, "push-derived", "push", "propose", "attempt-push"):
         return web.json_response({"error": "Invalid mode", "mode": mode}, status=400)
+    if mode is not None:
+        check_admin(request)
     url = URL(publisher_url) / campaign / codebase / "publish"
     if request["user"]:
         try:

--- a/py/janitor/site/cupboard/__init__.py
+++ b/py/janitor/site/cupboard/__init__.py
@@ -31,7 +31,7 @@ from jinja2 import select_autoescape
 from janitor.site import template_loader
 from janitor.vcs import get_vcs_managers_from_config
 
-from .. import check_logged_in, is_admin, is_qa_reviewer, worker_link_is_global
+from .. import check_admin, check_logged_in, is_admin, is_qa_reviewer, worker_link_is_global
 from ..common import html_template
 from ..pkg import MergeProposalUserUrlResolver
 from ..setup import setup_postgres
@@ -72,6 +72,7 @@ ORDER BY finish_time DESC"""
 @routes.get("/cupboard/reprocess-logs", name="reprocess-logs")
 @html_template("cupboard/reprocess-logs.html")
 async def handle_reprocess_logs(request):
+    check_admin(request)
     return {}
 
 

--- a/tests/test_cupboard.py
+++ b/tests/test_cupboard.py
@@ -122,6 +122,12 @@ async def test_publish_history(aiohttp_client, db):
     assert resp.status == 200
 
 
+async def test_reprocess_logs_requires_admin(aiohttp_client, db):
+    client = await create_client(aiohttp_client, db)
+    resp = await client.get("/cupboard/reprocess-logs")
+    assert resp.status == 401
+
+
 def test_render_changeset():
     env = Environment(loader=template_loader)
     template = env.get_template("cupboard/changeset.html")

--- a/tests/test_site_simple.py
+++ b/tests/test_site_simple.py
@@ -154,3 +154,22 @@ async def test_candidates_with_multiple_unscored_does_not_500(
     client = await aiohttp_client(app)
     resp = await client.get("/lintian-fixes/candidates")
     assert resp.status == 200
+
+
+async def test_codebase_publish_explicit_mode_requires_admin(aiohttp_client):
+    _private_app, app = await create_app(config=create_config(), redis=FakeRedis())
+    client = await aiohttp_client(app)
+    resp = await client.post(
+        "/lintian-fixes/c/foo/publish", data={"mode": "propose"}
+    )
+    assert resp.status == 401
+
+
+async def test_codebase_publish_without_mode_does_not_require_admin(aiohttp_client):
+    _private_app, app = await create_app(config=create_config(), redis=FakeRedis())
+    client = await aiohttp_client(app)
+    resp = await client.post("/lintian-fixes/c/foo/publish", data={})
+    # No publisher configured in this test app, so the request fails trying
+    # to reach it - the point here is it fails past the admin check, not at
+    # it (a 401 would mean the no-mode case wrongly started requiring admin).
+    assert resp.status != 401


### PR DESCRIPTION
(rescued from a caretaker-janitor branch)