### PR TITLE
auto_upload: fix KeyError: name crash on non-build result messages

### DIFF
--- a/py/janitor/debian/auto_upload.py
+++ b/py/janitor/debian/auto_upload.py
@@ -136,6 +136,19 @@ async def upload_build_result(
             )
 
 
+def is_debian_upload_target(result: dict, distributions: Optional[list[str]]) -> bool:
+    # a non-success run publishes "target": {}, so "code" has to be
+    # checked before "target"["name"] to avoid a KeyError
+    if result["code"] != "success":
+        return False
+    if result["target"]["name"] != "debian":
+        return False
+    return (
+        not distributions
+        or result["target"]["details"]["build_distribution"] in distributions
+    )
+
+
 async def listen_to_runner(
     redis,
     artifact_manager,
@@ -147,12 +160,7 @@ async def listen_to_runner(
     async def handle_result_message(msg):
         result = json.loads(msg["data"])
 
-        if result["target"]["name"] != "debian":
-            return
-        if (
-            not distributions
-            or result["target"]["details"]["build_distribution"] in distributions
-        ):
+        if is_debian_upload_target(result, distributions):
             await upload_build_result(
                 result["log_id"],
                 artifact_manager,

--- a/tests/test_auto_upload.py
+++ b/tests/test_auto_upload.py
@@ -1,0 +1,52 @@
+#!/usr/bin/python
+# Copyright (C) 2026 Jelmer Vernooij <jelmer@jelmer.uk>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+from janitor.debian.auto_upload import is_debian_upload_target
+
+
+def test_non_success_run_has_no_target_name():
+    # regression: a non-success run publishes "target": {}, which crashed
+    # handle_result_message with KeyError: 'name' before this check
+    result = {
+        "code": "codemod-error",
+        "log_id": "abc123",
+        "target": {},
+    }
+    assert is_debian_upload_target(result, None) is False
+
+
+def test_successful_debian_build_matches():
+    result = {
+        "code": "success",
+        "log_id": "abc123",
+        "target": {
+            "name": "debian",
+            "details": {"build_distribution": "lintian-fixes"},
+        },
+    }
+    assert is_debian_upload_target(result, None) is True
+    assert is_debian_upload_target(result, ["lintian-fixes"]) is True
+    assert is_debian_upload_target(result, ["other-distribution"]) is False
+
+
+def test_successful_non_debian_target_is_skipped():
+    result = {
+        "code": "success",
+        "log_id": "abc123",
+        "target": {"name": "generic", "details": {}},
+    }
+    assert is_debian_upload_target(result, None) is False


### PR DESCRIPTION
handle_result_message reads result["target"]["name"] on every message published to the "result" redis channel. JanitorResult.json() in runner.py only fills in target with a name when self.builder_result is set, and emits target: {} otherwise, which is the case for any run that did not reach the build stage (codemod failure, VCS push failure, and so on). Since most runs on a real instance do not succeed, this hits target: {} constantly and crash-loops the auto_upload service.

The code != success guard that used to sit in front of this access was dropped in 1e714202 (Migrate to redis proper, 2022-11-04) during a redis client rewrite; restore it via a is_debian_upload_target() helper, extracted so the failure shape is directly testable.

(rescued from a caretaker-janitor branch)