### PR TITLE
publish: skip merge proposals with no rate-limit bucket

### DIFF
--- a/py/janitor/publish.py
+++ b/py/janitor/publish.py
@@ -3479,6 +3479,10 @@ async def refresh_bucket_mp_counts(db, bucket_rate_limiter):
              GROUP BY 1, 2
              """
         ):
+            if row["rate_limit_bucket"] is None:
+                # No bucket assigned, nothing to rate-limit against.
+                # Passing None through here crashes on the Rust side.
+                continue
             per_bucket.setdefault(row["status"], {})[row["rate_limit_bucket"]] = row[
                 "c"
             ]

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -1,0 +1,34 @@
+#!/usr/bin/python
+# Copyright (C) 2022 Jelmer Vernooij <jelmer@jelmer.uk>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+
+from janitor._publish import FixedRateLimiter
+from janitor.publish import refresh_bucket_mp_counts
+
+
+async def test_refresh_bucket_mp_counts_skips_unbucketed(db):
+    # regression: a merge proposal with no rate_limit_bucket comes through
+    # as a Python None key, which PyO3 rejects when handed to the Rust
+    # rate limiter - crashed publish on startup on any real deployment.
+    async with db.acquire() as conn:
+        await conn.execute(
+            "INSERT INTO merge_proposal (url, status) VALUES ($1, $2)",
+            "https://example.com/foo/merge_requests/1",
+            "open",
+        )
+
+    await refresh_bucket_mp_counts(db, FixedRateLimiter(10))


### PR DESCRIPTION
(rescued from a caretaker-janitor branch)