### PR TITLE
runner: bound additional_colocated_branches with the same timeout as its sibling remote-branch calls

### DIFF
--- a/py/janitor/runner.py
+++ b/py/janitor/runner.py
@@ -2643,9 +2643,18 @@ async def next_item(
                 active_run.vcs_info["branch_url"] = full_branch_url(main_branch).rstrip(
                     "/"
                 )
-                additional_colocated_branches = await asyncio.to_thread(
-                    builder.additional_colocated_branches, main_branch
-                )
+                try:
+                    additional_colocated_branches = await to_thread_timeout(
+                        REMOTE_BRANCH_OPEN_TIMEOUT,
+                        builder.additional_colocated_branches,
+                        main_branch,
+                    )
+                except asyncio.TimeoutError:
+                    logging.debug(
+                        "Timeout listing colocated branches for %s",
+                        vcs_info["branch_url"],
+                    )
+                    additional_colocated_branches = None
                 vcs_type = get_branch_vcs_type(main_branch)
                 if not item.refresh:
                     with span.new_child("resume-branch:open"):

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -17,6 +17,7 @@
 
 import asyncio
 import os
+import time
 from datetime import datetime, timedelta
 from io import BytesIO
 
@@ -41,6 +42,7 @@ from janitor.runner import (
     is_log_filename,
     store_change_set,
     store_run,
+    to_thread_timeout,
 )
 from janitor.vcs import get_vcs_managers
 
@@ -944,3 +946,40 @@ async def test_schedule_unknown_run_id_returns_404(aiohttp_client, db, tmp_path)
     resp = await client.post("/schedule", json={"run_id": "nonexistent"})
     assert resp.status == 404
     await qp.stop()
+
+
+async def test_to_thread_timeout_bounds_a_hanging_call():
+    def hangs_forever():
+        # Simulates a synchronous VCS/network call (e.g.
+        # additional_colocated_branches against a remote that never
+        # responds) that asyncio.to_thread alone would wait on
+        # indefinitely, since cancelling the awaiting coroutine does not
+        # stop the underlying thread. Bounded to 2s rather than an unset
+        # threading.Event().wait(): asyncio.to_thread runs this on the
+        # default (non-daemon) ThreadPoolExecutor, and a thread that
+        # never returns blocks interpreter shutdown forever, hanging the
+        # whole test run instead of just this test.
+        time.sleep(2)
+
+    start = time.monotonic()
+    with pytest.raises(asyncio.TimeoutError):
+        # The outer 5s wait_for is only a safety net so a regression
+        # fails the test instead of hanging the suite; the assertion
+        # below is what actually proves to_thread_timeout enforced its
+        # own, much shorter timeout.
+        await asyncio.wait_for(to_thread_timeout(0.1, hangs_forever), timeout=5.0)
+    assert time.monotonic() - start < 1.0
+
+
+async def test_to_thread_timeout_returns_result():
+    def quick():
+        return 42
+
+    assert await to_thread_timeout(5.0, quick) == 42
+
+
+async def test_to_thread_timeout_none_disables_timeout():
+    def quick():
+        return "no timeout"
+
+    assert await to_thread_timeout(None, quick) == "no timeout"


### PR DESCRIPTION
(rescued from a caretaker-janitor branch)