### PR TITLE
site: implement the missing schedule-a-new-run API route

### DIFF
--- a/py/janitor/site/api.py
+++ b/py/janitor/site/api.py
@@ -102,6 +102,47 @@ class ScheduleResultSchema(Schema):
 
 
 @response_schema(ScheduleResultSchema())
+@routes.post("/{campaign}/c/{codebase}/schedule", name="codebase-schedule")
+async def handle_codebase_schedule(request):
+    codebase = request.match_info["codebase"]
+    campaign = request.match_info["campaign"]
+    post = await request.post()
+    offset = post.get("offset")
+    try:
+        refresh = bool(int(post.get("refresh", "0")))
+    except ValueError:
+        return web.json_response({"error": "invalid boolean for refresh"}, status=400)
+    if request["user"]:
+        try:
+            requester = request["user"]["email"]
+        except KeyError:
+            requester = request["user"]["name"]
+    else:
+        requester = "user from web UI"
+    json = {
+        "campaign": campaign,
+        "codebase": codebase,
+        "refresh": refresh,
+        "requester": requester,
+        "bucket": "manual",
+        "offset": offset,
+    }
+    url = URL(request.app["runner_url"]) / "schedule"
+    try:
+        async with request.app["http_client_session"].post(url, json=json) as resp:
+            ret = await resp.json()
+            if resp.status >= 400:
+                return web.json_response(ret, status=resp.status)
+    except ContentTypeError as e:
+        return web.json_response(
+            {"error": f"runner returned error {e.code}"}, status=400
+        )
+    except ClientConnectorError:
+        return web.json_response({"error": "unable to contact runner"}, status=502)
+    return web.json_response(ret)
+
+
+@response_schema(ScheduleResultSchema())
 @routes.post("/run/{run_id}/reschedule", name="run-reschedule")
 async def handle_run_reschedule(request):
     run_id = request.match_info["run_id"]
@@ -168,15 +209,18 @@ async def handle_schedule_control(request):
     queue_position_url = URL(request.app["runner_url"]) / "queue" / "position"
     try:
         async with request.app["http_client_session"].post(
-            schedule_url, json=json, raise_for_status=True
+            schedule_url, json=json
         ) as resp:
             ret = await resp.json()
+            if resp.status >= 400:
+                return web.json_response(ret, status=resp.status)
         async with request.app["http_client_session"].get(
             queue_position_url,
             params={"campaign": ret["campaign"], "codebase": ret["codebase"]},
-            raise_for_status=True,
         ) as resp:
             queue_position = await resp.json()
+            if resp.status >= 400:
+                return web.json_response(queue_position, status=resp.status)
     except ContentTypeError as e:
         return web.json_response(
             {"error": f"runner returned error {e.code}"}, status=400

--- a/tests/test_site_api.py
+++ b/tests/test_site_api.py
@@ -22,6 +22,12 @@ from janitor.config import read_string as read_config_string
 from janitor.site.api import create_app
 
 
+@web.middleware
+async def dummy_user_middleware(request, handler):
+    request["user"] = None
+    return await handler(request)
+
+
 async def create_client(aiohttp_client, db, *, runner_url=None, publisher_url=None):
     config = read_config_string("")
     app = create_app(
@@ -32,6 +38,7 @@ async def create_client(aiohttp_client, db, *, runner_url=None, publisher_url=No
         config=config,
         db=db,
     )
+    app.middlewares.insert(0, dummy_user_middleware)
     # In production this app is mounted as a subapp of janitor.site.simple,
     # which is what calls aiozipkin.setup() - do the same here since these
     # handlers use aiozipkin.request_span(request).
@@ -39,6 +46,12 @@ async def create_client(aiohttp_client, db, *, runner_url=None, publisher_url=No
     tracer = await aiozipkin.create_custom(endpoint)
     aiozipkin.setup(app, tracer)
     return await aiohttp_client(app)
+
+
+async def create_runner_client(aiohttp_client, handler):
+    runner_app = web.Application()
+    runner_app.router.add_post("/schedule", handler)
+    return await aiohttp_client(runner_app)
 
 
 async def test_handle_queue_forwards_limit(aiohttp_client, db):
@@ -81,3 +94,125 @@ async def test_handle_queue_without_limit(aiohttp_client, db):
     resp = await client.get("/queue")
     assert resp.status == 200
     assert await resp.json() == []
+
+
+async def test_codebase_schedule_forwards_to_runner(aiohttp_client, db):
+    async def handle_schedule(request):
+        body = await request.json()
+        assert body["campaign"] == "mycampaign"
+        assert body["codebase"] == "foo"
+        assert body["requester"] == "user from web UI"
+        assert body["bucket"] == "manual"
+        return web.json_response(
+            {"campaign": "mycampaign", "codebase": "foo", "queue_position": 1}
+        )
+
+    runner_client = await create_runner_client(aiohttp_client, handle_schedule)
+    client = await create_client(
+        aiohttp_client, db, runner_url=str(runner_client.make_url("/"))
+    )
+
+    resp = await client.post("/mycampaign/c/foo/schedule")
+    assert resp.status == 200
+    body = await resp.json()
+    assert body == {"campaign": "mycampaign", "codebase": "foo", "queue_position": 1}
+
+
+async def test_codebase_schedule_uses_authenticated_requester(aiohttp_client, db):
+    async def handle_schedule(request):
+        body = await request.json()
+        assert body["requester"] == "alice@example.com"
+        return web.json_response({"campaign": "mycampaign", "codebase": "foo"})
+
+    runner_client = await create_runner_client(aiohttp_client, handle_schedule)
+    config = read_config_string("")
+    app = create_app(
+        publisher_url=None,
+        runner_url=str(runner_client.make_url("/")),
+        vcs_managers={},
+        differ_url=None,
+        config=config,
+        db=db,
+    )
+
+    @web.middleware
+    async def user_middleware(request, handler):
+        request["user"] = {"email": "alice@example.com", "groups": []}
+        return await handler(request)
+
+    app.middlewares.insert(0, user_middleware)
+    client = await aiohttp_client(app)
+
+    resp = await client.post("/mycampaign/c/foo/schedule")
+    assert resp.status == 200
+
+
+async def test_codebase_schedule_invalid_refresh_returns_400(aiohttp_client, db):
+    async def handle_schedule(request):
+        raise AssertionError("runner should not be contacted")
+
+    runner_client = await create_runner_client(aiohttp_client, handle_schedule)
+    client = await create_client(
+        aiohttp_client, db, runner_url=str(runner_client.make_url("/"))
+    )
+
+    resp = await client.post(
+        "/mycampaign/c/foo/schedule", data={"refresh": "notabool"}
+    )
+    assert resp.status == 400
+    assert await resp.json() == {"error": "invalid boolean for refresh"}
+
+
+async def test_codebase_schedule_forwards_runner_error_status(aiohttp_client, db):
+    async def handle_schedule(request):
+        return web.json_response({"reason": "no such campaign"}, status=404)
+
+    runner_client = await create_runner_client(aiohttp_client, handle_schedule)
+    client = await create_client(
+        aiohttp_client, db, runner_url=str(runner_client.make_url("/"))
+    )
+
+    resp = await client.post("/mycampaign/c/foo/schedule")
+    assert resp.status == 404
+    assert await resp.json() == {"reason": "no such campaign"}
+
+
+async def test_codebase_schedule_runner_returns_non_json_error(aiohttp_client, db):
+    async def handle_schedule(request):
+        return web.Response(status=400, text="bad request", content_type="text/plain")
+
+    runner_client = await create_runner_client(aiohttp_client, handle_schedule)
+    client = await create_client(
+        aiohttp_client, db, runner_url=str(runner_client.make_url("/"))
+    )
+
+    resp = await client.post("/mycampaign/c/foo/schedule")
+    assert resp.status == 400
+    body = await resp.json()
+    assert body["error"] == "runner returned error 400"
+
+
+async def test_codebase_schedule_runner_unreachable_returns_502(aiohttp_client, db):
+    client = await create_client(
+        aiohttp_client, db, runner_url="http://127.0.0.1:1/"
+    )
+
+    resp = await client.post("/mycampaign/c/foo/schedule")
+    assert resp.status == 502
+    assert await resp.json() == {"error": "unable to contact runner"}
+
+
+async def test_schedule_control_forwards_runner_error_status(aiohttp_client, db):
+    async def handle_schedule_control(request):
+        return web.json_response({"reason": "run not found"}, status=404)
+
+    runner_app = web.Application()
+    runner_app.router.add_post("/schedule-control", handle_schedule_control)
+    runner_client = await aiohttp_client(runner_app)
+    client = await create_client(
+        aiohttp_client, db, runner_url=str(runner_client.make_url("/"))
+    )
+
+    resp = await client.post("/run/somerun/schedule-control")
+    assert resp.status == 404
+    assert await resp.json() == {"reason": "run not found"}


### PR DESCRIPTION
(rescued from caretaker-janitor branch)