### PR TITLE
Dockerfile_worker: install ca-certificates in the final image, not just build stage

### DIFF
--- a/Dockerfile_worker
+++ b/Dockerfile_worker
@@ -36,6 +36,7 @@ RUN apt-get update --yes \
         iproute2 \
  && apt-get upgrade --yes \
  && apt-get satisfy --yes --no-install-recommends \
+        ca-certificates \
         libpython3-dev \
         python3-breezy \
         dpkg-dev \


### PR DESCRIPTION
(resuced from caretaker-janitor branch)