### PR TITLE
Fix queue assignment race condition

### DIFF
--- a/py/janitor/queue.py
+++ b/py/janitor/queue.py
@@ -156,7 +156,7 @@ LEFT JOIN codebase ON codebase.name = queue.codebase
             conditions.append(f"queue.codebase = ${len(args)}")
         if campaign:
             args.append(campaign)
-            conditions.append("queue.suite = ${len(args)}")
+            conditions.append(f"queue.suite = ${len(args)}")
         if exclude_hosts:
             args.append(exclude_hosts)
             # TODO(jelmer): Use codebase.hostname when kali upgrades to postgres 12+

--- a/py/janitor/runner.py
+++ b/py/janitor/runner.py
@@ -1582,14 +1582,17 @@ class QueueProcessor:
         }
 
     async def register_run(self, active_run: ActiveRun) -> None:
-        # Ideally we'd do this check *in* the transaction, but
-        # fakeredis doesn't seem to do Pipeline.hget()
-        run_id = await self.redis.hget("assigned-queue-items", str(active_run.queue_id))
-        if run_id:
+        # HSETNX makes the claim atomic - hget then hset (below) could race
+        claimed = await self.redis.hsetnx(
+            "assigned-queue-items", str(active_run.queue_id), active_run.log_id
+        )
+        if not claimed:
+            run_id = await self.redis.hget(
+                "assigned-queue-items", str(active_run.queue_id)
+            )
             raise QueueItemAlreadyClaimed(active_run.queue_id, run_id)
         async with self.redis.pipeline() as tr:
             tr.hset("active-runs", active_run.log_id, json.dumps(active_run.json()))
-            tr.hset("assigned-queue-items", str(active_run.queue_id), active_run.log_id)
             tr.hset("last-keepalive", active_run.log_id, datetime.utcnow().isoformat())
             await tr.execute()
         await self.redis.publish("queue", json.dumps(await self.status_json()))

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -46,3 +46,25 @@ async def test_vcs_only(con):
     assert queue_item.codebase == "foo"
     assert queue_item.campaign == "bar"
     assert vcs_info == {"vcs_type": "git"}
+
+
+async def test_next_item_filters_by_campaign(con):
+    # regression: a missing `f` on the campaign condition sent Postgres the
+    # literal `${len(args)}`, so any call with campaign= raised a syntax error
+    queue = Queue(con)
+    await con.execute("INSERT INTO codebase (name) VALUES ('foo')")
+    await queue.add(codebase="foo", campaign="alpha", command="true")
+    await queue.add(codebase="foo", campaign="beta", command="true")
+
+    queue_item, _ = await queue.next_item(campaign="beta")
+    assert queue_item is not None
+    assert queue_item.campaign == "beta"
+
+
+async def test_next_item_campaign_no_match(con):
+    queue = Queue(con)
+    await con.execute("INSERT INTO codebase (name) VALUES ('foo')")
+    await queue.add(codebase="foo", campaign="alpha", command="true")
+
+    queue_item, _ = await queue.next_item(campaign="beta")
+    assert queue_item is None

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -15,6 +15,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
+import asyncio
 import os
 from datetime import datetime, timedelta
 from io import BytesIO
@@ -30,6 +31,7 @@ from janitor.logs import LogFileManager
 from janitor.runner import (
     ActiveRun,
     Backchannel,
+    QueueItemAlreadyClaimed,
     QueueProcessor,
     WorkerResult,
     _naive_utc,
@@ -827,3 +829,49 @@ async def test_schedule_unknown_run_id_returns_404(aiohttp_client, db, tmp_path)
     resp = await client.post("/schedule", json={"run_id": "nonexistent"})
     assert resp.status == 404
     await qp.stop()
+
+
+def _make_active_run(*, queue_id, log_id, codebase="foo"):
+    return ActiveRun(
+        campaign="test",
+        change_set=None,
+        command="blah",
+        queue_id=queue_id,
+        log_id=log_id,
+        start_time=datetime.utcnow(),
+        codebase=codebase,
+        vcs_info={},
+        backchannel=Backchannel(),
+        worker_name="tester",
+        instigated_context=None,
+        estimated_duration=timedelta(seconds=10),
+    )
+
+
+async def test_register_run_rejects_duplicate_queue_id():
+    qp = await create_queue_processor()
+    await qp.register_run(_make_active_run(queue_id=1, log_id="first"))
+    with pytest.raises(QueueItemAlreadyClaimed):
+        await qp.register_run(_make_active_run(queue_id=1, log_id="second"))
+    # only the first claim's side-effects are visible
+    assert await qp.redis.hkeys("active-runs") == [b"first"]
+    assert await qp.redis.hkeys("assigned-queue-items") == [b"1"]
+    assert await qp.redis.hget("assigned-queue-items", "1") == b"first"
+
+
+async def test_register_run_concurrent_claims_pick_exactly_one():
+    # regression: hget-then-hset let two register_run calls both claim the
+    # same queue_id. HSETNX makes the claim atomic - exactly one wins.
+    qp = await create_queue_processor()
+    results = await asyncio.gather(
+        qp.register_run(_make_active_run(queue_id=42, log_id="a")),
+        qp.register_run(_make_active_run(queue_id=42, log_id="b")),
+        return_exceptions=True,
+    )
+    successes = [r for r in results if r is None]
+    failures = [r for r in results if isinstance(r, QueueItemAlreadyClaimed)]
+    assert len(successes) == 1
+    assert len(failures) == 1
+    winner = await qp.redis.hget("assigned-queue-items", "42")
+    assert winner in (b"a", b"b")
+    assert await qp.redis.hkeys("active-runs") == [winner]


### PR DESCRIPTION
Use HSETNX to make the assigned-queue-items claim atomic, closing a race where two register_run calls could both succeed for the same queue_id. Also fixes a missing f-string prefix in Queue.next_item that broke campaign filtering.

(rescued from caretaker-janitor branch)