### PR TITLE
UI: link setup-gap empty states to docs, document candidate/codebase HTTP API

### DIFF
--- a/docs/flow.md
+++ b/docs/flow.md
@@ -37,6 +37,24 @@ can be really complicated - allowing for more optimal scheduling - or really
 simple, in which case they just output a candidate for each package in a suite
 with fixed settings for value and succes_chance.
 
+Injecting codebases and candidates directly
+===========================================
+
+The runner also accepts codebases and candidates directly over its own
+internal HTTP API - the same interface a candidate generation script
+itself calls:
+
+* ``POST /codebases`` - a JSON array of ``{"name": ..., "branch_url": ...}``
+  objects.
+* ``POST /candidates`` - a JSON array of
+  ``{"codebase": ..., "campaign": ..., "value": ...}`` objects, where
+  ``campaign`` must match a configured campaign name (e.g.
+  ``lintian-fixes``) and ``codebase`` an already-registered codebase
+  name. ``command`` and ``value`` are both optional; ``command``
+  defaults to the campaign's own configured command when omitted.
+
+Both endpoints run on the runner's internal port, not the public site.
+
 Scheduling
 ==========
 

--- a/py/janitor/site/templates/cupboard/history.html
+++ b/py/janitor/site/templates/cupboard/history.html
@@ -13,6 +13,9 @@
         <p>
             For what's coming up, see the <a href="queue">queue</a>.
         </p>
+        {% if not history %}
+            <p>No runs yet. If this stays empty, the pipeline may never have been given any candidates to work on - see <a href="https://github.com/janitor-team/janitor/blob/main/docs/flow.md#injecting-codebases-and-candidates-directly">Injecting codebases and candidates directly</a>.</p>
+        {% else %}
         <p>Last {{ count }} runs:</p>
         <table class="docutils" border="1">
             <colgroup>
@@ -63,5 +66,6 @@
                 {% endfor %}
             </tbody>
         </table>
+        {% endif %}
     </div>
 {% endblock body %}

--- a/py/janitor/site/templates/cupboard/queue.html
+++ b/py/janitor/site/templates/cupboard/queue.html
@@ -154,7 +154,7 @@
                             </td>
                         </tr>
                     {% else %}
-                        <tr><td colspan="5">Nothing queued.</td></tr>
+                        <tr><td colspan="5">Nothing queued. If this stays empty, no candidates may have been registered yet - see <a href="https://github.com/janitor-team/janitor/blob/main/docs/flow.md#injecting-codebases-and-candidates-directly">Injecting codebases and candidates directly</a>.</td></tr>
                     {% endfor %}
                 </tbody>
             </table>

--- a/py/janitor/site/templates/cupboard/ready-list.html
+++ b/py/janitor/site/templates/cupboard/ready-list.html
@@ -26,7 +26,7 @@
                 {% endfor %}
             </ul>
         {% else %}
-            <p>Nothing is ready to publish right now. Check the <a href="/cupboard/queue">queue</a> for work in progress or the <a href="/cupboard/review">review queue</a>.</p>
+            <p>Nothing is ready to publish right now. Check the <a href="/cupboard/queue">queue</a> for work in progress or the <a href="/cupboard/review">review queue</a>. If those are empty too, see <a href="https://github.com/janitor-team/janitor/blob/main/docs/flow.md#injecting-codebases-and-candidates-directly">Injecting codebases and candidates directly</a>.</p>
         {% endif %}
     </div>
 {% endblock body %}

--- a/py/janitor/site/templates/cupboard/workers.html
+++ b/py/janitor/site/templates/cupboard/workers.html
@@ -76,7 +76,7 @@
                 });
             </script>
         {% else %}
-            <p>No workers have connected yet.</p>
+            <p>No workers have connected yet. See <a href="https://github.com/janitor-team/janitor/blob/main/docs/production.md#database">Worker registration</a> in the production docs.</p>
         {% endif %}
     </div>
 {% endblock body %}

--- a/py/janitor/site/templates/generic/candidates.html
+++ b/py/janitor/site/templates/generic/candidates.html
@@ -18,7 +18,7 @@
                 {% endfor %}
             </ul>
         {% else %}
-            <p>No candidates yet.</p>
+            <p>No candidates yet. See <a href="https://github.com/janitor-team/janitor/blob/main/docs/flow.md#injecting-codebases-and-candidates-directly">Injecting codebases and candidates directly</a>.</p>
         {% endif %}
     </div>
 {% endblock body %}

--- a/py/janitor/site/templates/generic/done.html
+++ b/py/janitor/site/templates/generic/done.html
@@ -26,7 +26,7 @@
         </form>
         {% set ns = namespace(last_date=None, run_date=None) %}
         {% if not runs %}
-            <p>No changes have been merged or pushed yet.</p>
+            <p>No changes have been merged or pushed yet. If this stays empty, check whether any candidates have been registered for this campaign - see <a href="https://github.com/janitor-team/janitor/blob/main/docs/flow.md#injecting-codebases-and-candidates-directly">Injecting codebases and candidates directly</a>.</p>
         {% else %}
         <ul>
             {% for run in runs %}

--- a/tests/test_cupboard.py
+++ b/tests/test_cupboard.py
@@ -17,6 +17,7 @@
 
 from datetime import datetime, timedelta
 
+import aiohttp_jinja2
 from aiohttp import web
 from jinja2 import Environment
 from yarl import URL
@@ -24,6 +25,7 @@ from yarl import URL
 from janitor.config import read_string as read_config_string
 from janitor.runner import store_change_set, store_run
 from janitor.site import (
+    TEMPLATE_ENV,
     classify_result_code,
     format_duration,
     format_timestamp,
@@ -57,6 +59,10 @@ async def create_client(aiohttp_client, db):
     )
     app["external_url"] = URL("http://example.com/")
     app.middlewares.insert(0, dummy_user_middleware)
+    # production wires these templates through janitor.site.simple's app,
+    # whose jinja env carries TEMPLATE_ENV - cupboard's own create_app()
+    # here is otherwise missing format_timestamp/format_duration/etc.
+    aiohttp_jinja2.get_env(app).globals.update(TEMPLATE_ENV)
     return await aiohttp_client(app)
 
 
@@ -108,6 +114,29 @@ async def test_history(aiohttp_client, db):
     client = await create_client(aiohttp_client, db)
     resp = await client.get("/cupboard/history")
     assert resp.status == 200
+    text = await resp.text()
+    assert "the pipeline may never have been given any candidates" in text
+    assert "<table" not in text
+
+
+async def test_history_with_runs(aiohttp_client, db):
+    client = await create_client(aiohttp_client, db)
+    async with db.acquire() as conn:
+        await _insert_codebase(conn, "foo")
+        now = datetime.utcnow()
+        await _insert_run(
+            conn,
+            run_id="somerun",
+            codebase="foo",
+            start_time=now - timedelta(minutes=30),
+            finish_time=now,
+        )
+
+    resp = await client.get("/cupboard/history")
+    assert resp.status == 200
+    text = await resp.text()
+    assert "the pipeline may never have been given any candidates" not in text
+    assert "<table" in text
 
 
 async def test_queue(aiohttp_client, db):


### PR DESCRIPTION
Also fixes a heading underline in flow.md that was one character too long for its title, found during review.

(rescued from caretaker-janitor branch)