### PR TITLE
publish, runner: load forge plugins generically instead of one import per forge

### DIFF
--- a/py/janitor/publish.py
+++ b/py/janitor/publish.py
@@ -39,9 +39,7 @@ import aioredlock
 import aiozipkin
 import asyncpg
 import asyncpg.pool
-import breezy.plugins.github  # noqa: F401
-import breezy.plugins.gitlab  # noqa: F401
-import breezy.plugins.launchpad  # noqa: F401
+import breezy.plugin
 import gpg
 from aiohttp import ClientSession, web
 from aiohttp.web_middlewares import normalize_path_middleware
@@ -97,6 +95,7 @@ from .schedule import CandidateUnavailable, do_schedule, do_schedule_control
 from .vcs import VcsManager, get_vcs_managers_from_config
 
 override_launchpad_consumer_name()
+breezy.plugin.load_plugins()
 
 
 EXISTING_RUN_RETRY_INTERVAL = 30

--- a/py/janitor/runner.py
+++ b/py/janitor/runner.py
@@ -40,9 +40,7 @@ import aiojobs
 import aiozipkin
 import asyncpg
 import asyncpg.pool
-import breezy.plugins.github  # noqa: F401
-import breezy.plugins.gitlab  # noqa: F401
-import breezy.plugins.launchpad  # noqa: F401
+import breezy.plugin
 from aiohttp import (
     ClientConnectorError,
     ClientOSError,
@@ -114,6 +112,7 @@ from .vcs import (
 from .worker_creds import check_worker_creds
 
 override_launchpad_consumer_name()
+breezy.plugin.load_plugins()
 
 
 DEFAULT_RETRY_AFTER = 120

--- a/py/janitor/site/templates/about.html
+++ b/py/janitor/site/templates/about.html
@@ -25,7 +25,7 @@
                 provides abstractions over the version control system (<a href="https://git-scm.com/">Git</a>,
                 <a href="https://en.wikipedia.org/wiki/GNU_Bazaar">Bazaar</a>,
                 <a href="https://www.mercurial-scm.org/">Mercurial</a> &amp; <a href="https://subversion.apache.org/">Subversion</a>) and the supported hosting platforms (<a href="https://github.com/">GitHub</a>,
-                <a href="https://gitlab.com/">GitLab</a> &amp; <a href="https://launchpad.net/">Launchpad</a>).
+                <a href="https://gitlab.com/">GitLab</a>, <a href="https://about.gitea.com/">Gitea</a> &amp; <a href="https://launchpad.net/">Launchpad</a>).
             </li>
             <li>
                 <a class="reference external"


### PR DESCRIPTION
Matches the pattern just adopted on the Rust side ("worker: load breezy plugins before opening branches") - explicit imports for github/gitlab/launchpad already existed in both files before this Gitea PR; adding a fourth, gitea-specific import would have kept the same one-off pattern going rather than fixing it. breezy.plugin.load_plugins() is the Python equivalent of breezyshim::plugin::load_plugins() - it scans breezy.plugins.__path__ and loads everything installed there, so a future forge plugin (e.g. Forgejo) is picked up automatically without another explicit-import PR.

Also adds Gitea to the supported-hosting-platforms list on the about page, alongside GitHub, GitLab, and Launchpad.

(rescued from caretaker-janitor branch)